### PR TITLE
fix: update RESULTS_PATH to correct relative path for results.json

### DIFF
--- a/scraper/src/parse.py
+++ b/scraper/src/parse.py
@@ -2,7 +2,7 @@ from scraper import Scraper
 
 if __name__ == "__main__":
     URL = "https://agrochowski.pl/"
-    RESULTS_PATH = "../results/results.json"
+    RESULTS_PATH = "scraper/results/results.json"
 
 
     scraper = Scraper(URL)


### PR DESCRIPTION
This pull request updates the path to the results file in the `scraper/src/parse.py` script to improve consistency with the project structure.

Path and configuration update:

* Changed the value of `RESULTS_PATH` from `"../results/results.json"` to `"scraper/results/results.json"` in `scraper/src/parse.py` to better align with the expected directory structure.